### PR TITLE
Do not set release as draft when creating releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,7 +169,7 @@ jobs:
       - name: GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          draft: true
+          draft: false
           files: dist/**
           generate_release_notes: true
           append_body: true


### PR DESCRIPTION
Do not set release as draft when creating releases